### PR TITLE
Handle protowire.ConsumeField errors not consuming any data

### DIFF
--- a/pkg/protodump/scan.go
+++ b/pkg/protodump/scan.go
@@ -69,6 +69,10 @@ func Scan(data []byte) [][]byte {
 		}
 
 		length := consumeBytes(data, start)
+		if start == 0 && length == 0 {
+			data = data[index+1:]
+			continue
+		}
 		results = append(results, data[start:start+length])
 		data = data[start+length:]
 	}


### PR DESCRIPTION
I encountered cases where ConsumeField will return an error and consumeBytes will not advance the position. This results in a infinite loop (and memory usage). Skipping to the next byte now to ensure progress.