### PR TITLE
Ground scanning using FileDescriptorProto fields.

### DIFF
--- a/cmd/protodump/main.go
+++ b/cmd/protodump/main.go
@@ -78,6 +78,7 @@ func main() {
 	var file = flag.String("file", "", "The file to extract definitions from")
 	var output = flag.String("output", cwd, "The output directory to save definitions in (will be created if it doesn't exist). Defaults to current directory.")
 	flag.BoolVar(&debug, "v", false, "Verbose output")
+	var requiredFields = flag.Int("requiredFields", 3, "Minimum number of successfully parsed fields to be considered a valid FileDescriptorProto.")
 	flag.Parse()
 
 	if *file == "" {
@@ -86,7 +87,7 @@ func main() {
 		return
 	}
 
-	results, err := protodump.ScanFile(*file)
+	results, err := protodump.ScanFile(*file, *requiredFields)
 	if err != nil {
 		log.Fatalf("Got error scanning: %v\n", err)
 	}

--- a/pkg/protodump/scan.go
+++ b/pkg/protodump/scan.go
@@ -4,61 +4,98 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
+	"maps"
+	"slices"
 
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
 const scan = ".proto"
-const magicByte = 0xa
+var tags = map[string]uint64{
+	"name":              0xa,
+	"package":           0x12,
+	"dependency":        0x1a,
+	"public_dependency": 0x50,
+	"weak_dependency":   0x58,
+	"message_type":      0x22,
+	"enum_type":         0x2a,
+	"service":           0x32,
+	"extension":         0x3a,
+	"options":           0x42,
+	"source_code_info":  0x4a,
+	"syntax":            0x62,
+	"edition":           0x70,
+}
 
-func consumeBytes(data []byte, position int) (int, error) {
+func consumeBytes(data []byte, position int, requiredFields int) (int, error) {
 	start := position
-	consumedFieldOne := false
+	validTags := slices.Collect(maps.Values(tags))
+	seenName := false
+	seenFields := 0
+	
 	for {
-		number, _, length := protowire.ConsumeField(data[position:])
+		if position >= len(data) {
+			goto EndOfData
+		}
+
+		tag, n := protowire.ConsumeVarint(data[position:])
+		// Treat "invalid field number" as end of data, not an error
+		if n <= 0 || !slices.Contains(validTags, tag) {
+			goto EndOfData
+		}
+		if tag == tags["name"] {
+			if seenName {
+				// Only consume Field 1 once (to handle the case where protobuf definitions are adjacent in program memory)
+				goto EndOfData
+			}
+			seenName = true
+		}
+
+		fieldNum, _, length := protowire.ConsumeField(data[position:])
 		if length < 0 {
 			err := protowire.ParseError(length)
-			// Treat "invalid field number" as end of data, not an error
-			if strings.Contains(err.Error(), "invalid field number") {
-				return position - start, nil
-			}
 			// Return other parse errors as actual errors
 			return position - start, fmt.Errorf("couldn't consume proto bytes: %w", err)
 		}
 
-		// Prevent infinite loop - if we can't consume any bytes, we're done
-		if length == 0 {
-			return position - start, nil
+		seenFields += 1
+
+		if fieldNum == 1 {
+			seenName = true
 		}
 
-		// Only consume Field 1 once (to handle the case where protobuf definitions are adjacent
-		// in program memory)
-		if number == 1 {
-			if consumedFieldOne {
-				return position - start, nil
-			}
-			consumedFieldOne = true
+		// Prevent infinite loop - if we can't consume any bytes, we're done
+		if length == 0 {
+			goto EndOfData
 		}
 
 		position += length
-		
+
 		// Additional safety check - don't read beyond data bounds
 		if position-start >= len(data[start:]) {
-			return position - start, nil
+			goto EndOfData
 		}
 	}
+
+EndOfData:
+	err := func() error {
+		if seenFields < requiredFields {
+			return fmt.Errorf("couldn't consume proto bytes: incomplete proto definition")
+		}
+		return nil
+	}()
+	return position - start, err
 }
 
-func ScanFile(path string) ([][]byte, error) {
+func ScanFile(path string, requiredFields int) ([][]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open file: %w", err)
 	}
-	return Scan(data), nil
+	return Scan(data, requiredFields), nil
 }
 
-func Scan(data []byte) [][]byte {
+func Scan(data []byte, requiredFields int) [][]byte {
 	results := make([][]byte, 0)
 
 	for {
@@ -71,7 +108,7 @@ func Scan(data []byte) [][]byte {
 		//                      ^ no more bytes for varint
 		//                        ^ field 1 (file name)
 		//                             ^ type 2 (LEN)
-		start := bytes.LastIndexByte(data[:index], magicByte)
+		start := bytes.LastIndexByte(data[:index], byte(tags["name"]))
 		if start == -1 {
 			data = data[index+1:]
 			continue
@@ -79,11 +116,11 @@ func Scan(data []byte) [][]byte {
 
 		// If the "<file>.proto" filename is 10 characters long then the 0xa byte we found is actually
 		// the string length and not the start of the protobuf record, so go back 1 more
-		if index-start == (magicByte-len(scan)+1) && start > 0 && data[start-1] == magicByte {
+		if index-start == (int(tags["name"])-len(scan)+1) && start > 0 && data[start-1] == byte(tags["name"]) {
 			start -= 1
 		}
 
-		length, err := consumeBytes(data, start)
+		length, err := consumeBytes(data, start, requiredFields)
 		if err != nil {
 			fmt.Printf("%v\n", err)
 			if len(data) > index {


### PR DESCRIPTION
Currently the only field we actually look for is `name` which, given that it's tag is \n in ASCII, appears far more often in the data segment than we'd like and causes a number of false positives. Also we only treat invalid fields as EOD if they returned the "invalid field number" error which causes false negatives in protos that are followed by an erroniously valid field number.

We can solve both of these issues by grounding our search using field tags from FileDescriptorProto.

Both issues were observed when scanning `agy` v1.1.8.