### PR TITLE
Compile with protolegacy to avoid parsing issues with MessageSet.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -o bin/protodump cmd/protodump/main.go
+	go build -tags protolegacy -o bin/protodump cmd/protodump/main.go
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
MessageSet is sometimes included in Google binaries and is a compatibility layer on proto1. Compiling with the protolegacy flag ensures they're handled correctly.