### PR TITLE
Fixup unsupported editions to EditionUnstable.

### DIFF
--- a/pkg/protodump/proto.go
+++ b/pkg/protodump/proto.go
@@ -396,7 +396,16 @@ func NewFromBytes(payload []byte) (*ProtoDefinition, error) {
 	return NewFromDescriptor(&pb)
 }
 
+func FixUnsupportedEdition(fd *descriptorpb.FileDescriptorProto) {
+	if fd.Edition != nil {
+		if _, ok := descriptorpb.Edition_name[int32(*fd.Edition)]; !ok {
+			fd.Edition = descriptorpb.Edition_EDITION_UNSTABLE.Enum()
+		}
+	}
+}
+
 func NewFromDescriptor(pb *descriptorpb.FileDescriptorProto) (*ProtoDefinition, error) {
+	FixUnsupportedEdition(pb)
 	fileOptions := protodesc.FileOptions{AllowUnresolvable: true}
 	descriptor, err := fileOptions.New(pb, &protoregistry.Files{})
 

--- a/pkg/protodump/proto_test.go
+++ b/pkg/protodump/proto_test.go
@@ -63,3 +63,30 @@ func TestDefinitions(t *testing.T) {
 		})
 	}
 }
+
+func TestFixUnsupportedEdition(t *testing.T) {
+	t.Run("supported edition is unchanged", func(t *testing.T) {
+		fd := &descriptorpb.FileDescriptorProto{
+			Edition: descriptorpb.Edition_EDITION_2023.Enum(),
+		}
+		FixUnsupportedEdition(fd)
+		assert.Equal(t, descriptorpb.Edition_EDITION_2023, fd.GetEdition())
+	})
+
+	t.Run("unsupported edition is replaced with EDITION_UNSTABLE", func(t *testing.T) {
+		unsupportedVal := descriptorpb.Edition(99995)
+		fd := &descriptorpb.FileDescriptorProto{
+			Edition: unsupportedVal.Enum(),
+		}
+		FixUnsupportedEdition(fd)
+		assert.Equal(t, descriptorpb.Edition_EDITION_UNSTABLE, fd.GetEdition())
+	})
+
+	t.Run("nil edition remains nil", func(t *testing.T) {
+		fd := &descriptorpb.FileDescriptorProto{
+			Syntax: proto.String("proto3"),
+		}
+		FixUnsupportedEdition(fd)
+		assert.Nil(t, fd.Edition)
+	})
+}


### PR DESCRIPTION
Binaries built from google3 might use unreleased protobuf editions. If we come across one then coerce it to EDITION_UNSTABLE to ensure the extraction still succeeds.